### PR TITLE
fix(ci): sync release-protocol-check to canonical template — kills vundefined (#16)

### DIFF
--- a/.github/workflows/release-protocol-check.yml
+++ b/.github/workflows/release-protocol-check.yml
@@ -2,10 +2,12 @@ name: Release Protocol Drift Check
 # ASIF Release Protocol Enforcement — Layer 2 (ADR-036)
 # standards/release-protocol-enforcement.md
 #
-# Runs daily and verifies the manifest version matches:
+# Runs daily and on main pushes. Verifies the manifest version matches:
 #   - latest git tag matching v*
 #   - latest GitHub Release
 #   - latest published registry version (npm / cargo / pypi)
+# Also enforces release debt:
+#   - commits since latest v* tag must stay <= RELEASE_DEBT_THRESHOLD (default 15)
 #
 # On any drift, opens a `release-drift` labeled issue with a missing-step
 # checklist. Auto-closes when drift resolves on next run.
@@ -14,13 +16,19 @@ name: Release Protocol Drift Check
 #   cp ~/ASIF/scripts/templates/release-protocol-check.yml .github/workflows/release-protocol-check.yml
 #   git add .github/workflows/release-protocol-check.yml && commit && push
 #
-# Configuration is via the workflow_dispatch inputs OR repo variables:
+# Configuration is via .asif-ci, workflow_dispatch inputs, OR repo variables:
+#   RELEASE_PROTOCOL_MANIFEST: explicit manifest path
 #   REGISTRY: npm | cargo | pypi | none (default: auto-detect from manifest)
 #   PACKAGE_NAME: explicit package name (default: auto-detect)
+#   RELEASE_DEBT_THRESHOLD: P0 threshold for commits since latest v* tag (default: 15)
+#   RELEASE_DEBT_WARN_THRESHOLD: P1 warning threshold (default: 10)
 
 on:
   schedule:
     - cron: '0 8 * * *'  # 08:00 UTC daily
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       registry:
@@ -48,36 +56,97 @@ jobs:
           VERSION=""
           REGISTRY=""
           PKG_NAME=""
+          MANIFEST=""
 
-          if [ -f "package.json" ]; then
-            VERSION=$(node -p "require('./package.json').version" 2>/dev/null || true)
-            PKG_NAME=$(node -p "require('./package.json').name" 2>/dev/null || true)
-            # Public if has publishConfig OR private:false OR @nxtg/* scope OR no private flag
-            IS_PRIVATE=$(node -p "require('./package.json').private === true" 2>/dev/null || echo "false")
-            if [ "$IS_PRIVATE" != "true" ]; then
-              REGISTRY="npm"
+          if [ -f ".asif-ci" ]; then
+            MANIFEST=$(grep -oE '^release_protocol_manifest:[[:space:]]*[^[:space:]]+' .asif-ci | awk '{print $2}' | head -1 || true)
+          fi
+          if [ -z "$MANIFEST" ]; then
+            MANIFEST="${{ vars.RELEASE_PROTOCOL_MANIFEST }}"
+          fi
+          if [ -z "$MANIFEST" ]; then
+            if [ -f "package.json" ]; then
+              MANIFEST="package.json"
+            elif [ -f "Cargo.toml" ]; then
+              MANIFEST="Cargo.toml"
+            elif [ -f "pyproject.toml" ]; then
+              MANIFEST="pyproject.toml"
+            elif [ -f ".claude-plugin/plugin.json" ]; then
+              MANIFEST=".claude-plugin/plugin.json"
+            elif [ -f "action.yml" ]; then
+              MANIFEST="action.yml"
             fi
-          elif [ -f "Cargo.toml" ]; then
-            VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' Cargo.toml | head -1)
-            PKG_NAME=$(grep -oP '^name\s*=\s*"\K[^"]+' Cargo.toml | head -1)
-            if ! grep -q '^publish\s*=\s*false' Cargo.toml; then
-              REGISTRY="cargo"
-            fi
-          elif [ -f "pyproject.toml" ]; then
-            VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' pyproject.toml | head -1)
-            PKG_NAME=$(grep -oP '^name\s*=\s*"\K[^"]+' pyproject.toml | head -1)
-            REGISTRY="pypi"
           fi
 
-          # Override from workflow inputs
+          if [ "$MANIFEST" = "package.json" ] || [ "$(basename "$MANIFEST")" = "plugin.json" ]; then
+            VERSION=$(node -e "const p=process.argv[1]; const d=require('./' + p); process.stdout.write(d.version || '')" "$MANIFEST" 2>/dev/null || true)
+            PKG_NAME=$(node -e "const p=process.argv[1]; const d=require('./' + p); process.stdout.write(d.name || '')" "$MANIFEST" 2>/dev/null || true)
+            # Public if has publishConfig OR private:false OR @nxtg/* scope OR no private flag
+            IS_PRIVATE=$(node -e "const p=process.argv[1]; const d=require('./' + p); process.stdout.write(d.private === true ? 'true' : 'false')" "$MANIFEST" 2>/dev/null || echo "false")
+            if [ "$(basename "$MANIFEST")" = "plugin.json" ]; then
+              REGISTRY="none"
+            elif [ "$IS_PRIVATE" != "true" ]; then
+              REGISTRY="npm"
+            fi
+          elif [ "$MANIFEST" = "Cargo.toml" ]; then
+            VERSION=$(grep -oP '^version\s*=\s*"\K[^"]+' "$MANIFEST" | head -1)
+            PKG_NAME=$(grep -oP '^name\s*=\s*"\K[^"]+' "$MANIFEST" | head -1)
+            if ! grep -q '^publish\s*=\s*false' "$MANIFEST"; then
+              REGISTRY="cargo"
+            fi
+          elif [ "$MANIFEST" = "pyproject.toml" ]; then
+            VERSION=$(python3 -c "import tomllib; d=tomllib.load(open('$MANIFEST','rb')); print(d.get('project',{}).get('version','') or d.get('version',''))" 2>/dev/null || true)
+            PKG_NAME=$(python3 -c "import tomllib; d=tomllib.load(open('$MANIFEST','rb')); print(d.get('project',{}).get('name','') or d.get('name',''))" 2>/dev/null || true)
+            REGISTRY="pypi"
+          elif [ "$MANIFEST" = "action.yml" ]; then
+            REGISTRY="none"
+          fi
+
+          # Override from workflow inputs or repository variables
           if [ -n "${{ inputs.registry }}" ]; then
             REGISTRY="${{ inputs.registry }}"
+          elif [ -n "${{ vars.REGISTRY }}" ]; then
+            REGISTRY="${{ vars.REGISTRY }}"
+          fi
+          if [ -n "${{ vars.PACKAGE_NAME }}" ]; then
+            PKG_NAME="${{ vars.PACKAGE_NAME }}"
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "registry=$REGISTRY" >> "$GITHUB_OUTPUT"
           echo "pkg_name=$PKG_NAME" >> "$GITHUB_OUTPUT"
-          echo "Detected: name=$PKG_NAME version=v$VERSION registry=$REGISTRY"
+          echo "manifest=$MANIFEST" >> "$GITHUB_OUTPUT"
+          echo "Detected: manifest=$MANIFEST name=$PKG_NAME version=v$VERSION registry=$REGISTRY"
+
+      - name: Check release debt
+        id: debt
+        run: |
+          set -e
+          THRESHOLD="${{ vars.RELEASE_DEBT_THRESHOLD }}"
+          WARN_THRESHOLD="${{ vars.RELEASE_DEBT_WARN_THRESHOLD }}"
+          THRESHOLD="${THRESHOLD:-15}"
+          WARN_THRESHOLD="${WARN_THRESHOLD:-10}"
+
+          LATEST_TAG=$(git describe --tags --match 'v[0-9]*' --abbrev=0 HEAD 2>/dev/null || true)
+          if [ -n "$LATEST_TAG" ]; then
+            COMMITS_SINCE_TAG=$(git rev-list --count "$LATEST_TAG"..HEAD)
+          else
+            COMMITS_SINCE_TAG=$(git rev-list --count HEAD)
+          fi
+
+          STATUS="ok"
+          if [ "$COMMITS_SINCE_TAG" -gt "$THRESHOLD" ]; then
+            STATUS="p0"
+          elif [ "$COMMITS_SINCE_TAG" -gt "$WARN_THRESHOLD" ]; then
+            STATUS="warn"
+          fi
+
+          echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+          echo "commits_since_tag=$COMMITS_SINCE_TAG" >> "$GITHUB_OUTPUT"
+          echo "threshold=$THRESHOLD" >> "$GITHUB_OUTPUT"
+          echo "warn_threshold=$WARN_THRESHOLD" >> "$GITHUB_OUTPUT"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "Release debt: latest_tag=${LATEST_TAG:-none} commits_since_tag=$COMMITS_SINCE_TAG threshold=$THRESHOLD status=$STATUS"
 
       - name: Check git tag
         id: tag
@@ -148,7 +217,6 @@ jobs:
           echo "changelog_status=$STATUS" >> "$GITHUB_OUTPUT"
 
       - name: Evaluate drift + open/close issue
-        if: steps.detect.outputs.version != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -162,10 +230,19 @@ jobs:
           CHANGELOG_OK="${{ steps.changelog.outputs.changelog_status }}"
           REGISTRY="${{ steps.detect.outputs.registry }}"
           PKG="${{ steps.detect.outputs.pkg_name }}"
+          MANIFEST="${{ steps.detect.outputs.manifest }}"
+          DEBT_STATUS="${{ steps.debt.outputs.status }}"
+          UNRELEASED="${{ steps.debt.outputs.commits_since_tag }}"
+          LATEST_TAG="${{ steps.debt.outputs.latest_tag }}"
+          DEBT_THRESHOLD="${{ steps.debt.outputs.threshold }}"
 
           DRIFT=false
           MISSING=""
 
+          if [ "$DEBT_STATUS" = "p0" ]; then
+            DRIFT=true
+            MISSING="$MISSING\n- [ ] Release debt is \`$UNRELEASED\` commits since \`${LATEST_TAG:-none}\` (P0 threshold: >$DEBT_THRESHOLD) — cut a release before landing more main commits"
+          fi
           if [ "$TAG_OK" = "missing" ]; then
             DRIFT=true
             MISSING="$MISSING\n- [ ] Git tag \`$TAG\` is missing — run: \`git tag $TAG && git push origin $TAG\`"
@@ -188,14 +265,18 @@ jobs:
             MISSING="$MISSING\n- [ ] CHANGELOG.md still has \`[Unreleased]\` — roll to \`[v$VERSION] — $(date +%Y-%m-%d)\`"
           fi
 
-          ISSUE_TITLE="Release drift: v$VERSION bumped but train incomplete"
+          if [ -n "$VERSION" ]; then
+            ISSUE_TITLE="Release drift/debt: v$VERSION train incomplete"
+          else
+            ISSUE_TITLE="Release debt: $GITHUB_REPOSITORY exceeds threshold"
+          fi
           EXISTING=$(gh issue list --label "release-drift" --state open --json number,title --jq ".[] | select(.title == \"$ISSUE_TITLE\") | .number" | head -1)
 
           if $DRIFT; then
-            BODY=$(printf "Manifest declares **v%s** but the release train has gaps detected on %s UTC.\n\n## Missing Steps\n%b\n\n## Why this matters\nPer ADR-036, every public-package release must ship as one atomic bundle: tag + GH release + registry publish + CHANGELOG. Partial releases break downstream consumers and audit trail.\n\n## How to resolve\nComplete the steps above. This issue auto-closes on the next daily run when drift clears.\n\n---\n_Auto-generated by \`.github/workflows/release-protocol-check.yml\` — see \`standards/release-protocol-enforcement.md\` in ASIF._\n" "$VERSION" "$(date -u '+%Y-%m-%d %H:%M')" "$MISSING")
+            BODY=$(printf "Release protocol gaps detected on %s UTC.\n\n## State\n- Manifest: \`%s\`\n- Manifest version: \`%s\`\n- Latest release tag: \`%s\`\n- Commits since tag: \`%s\`\n- P0 release-debt threshold: \`>%s\`\n\n## Missing Steps\n%b\n\n## Why this matters\nPer ADR-036, every release-controlled repo must avoid both partial trains and silent release debt. More than 15 unreleased commits is a P0 because downstream users and auditors cannot see what shipped.\n\n## How to resolve\nComplete the steps above. This issue auto-closes on the next daily run when drift clears.\n\n---\n_Auto-generated by \`.github/workflows/release-protocol-check.yml\` — see \`standards/release-protocol-enforcement.md\` in ASIF._\n" "$(date -u '+%Y-%m-%d %H:%M')" "$MANIFEST" "${VERSION:-none}" "${LATEST_TAG:-none}" "$UNRELEASED" "$DEBT_THRESHOLD" "$MISSING")
 
             if [ -z "$EXISTING" ]; then
-              gh label create release-drift --color FFA500 --description "Release artifacts out of sync with manifest version" 2>/dev/null || true
+              gh label create release-drift --color FFA500 --description "Release artifacts or release debt out of sync with ASIF protocol" 2>/dev/null || true
               gh issue create --title "$ISSUE_TITLE" --body "$BODY" --label "release-drift"
               echo "Opened release-drift issue."
             else
@@ -207,6 +288,10 @@ jobs:
               gh issue close "$EXISTING" --comment "Release drift cleared on $(date -u '+%Y-%m-%d %H:%M UTC'). All artifacts in sync for v$VERSION."
               echo "Closed resolved release-drift issue #$EXISTING."
             else
-              echo "No drift. Release train for v$VERSION is intact."
+              echo "No drift. Release debt and train artifacts are within threshold."
             fi
+          fi
+
+          if $DRIFT; then
+            exit 1
           fi


### PR DESCRIPTION
## What
Syncs this repo's stale `release-protocol-check.yml` to the canonical ASIF template (`47d14acc`, 2026-05-06). Eliminates the `vundefined` false-positive driving daily issue #16.

## Root cause of #16
The stale workflow (installed pre-2026-05-06) resolved the version with:
```
VERSION=$(node -p "require('./package.json').version" 2>/dev/null || true)
```
`node -p` prints the literal string `undefined` for an absent field, and `|| true` swallows the **exit code but not stdout** — so `VERSION="undefined"`. Every step guard was `if: ... version != ''`; a non-empty `"undefined"` passed them all, templating `v$VERSION` → **`vundefined`** and re-commenting #16 daily since 2026-04-30.

It also read the **root** `package.json`, ignoring this repo's real manifest config.

## Fix
The canonical template:
- Resolves the version from `.asif-ci` → `release_protocol_manifest: packages/cli/package.json` (`@nxtg/faultline@0.8.0`) — so it enforces the **right** package.
- Uses `node -e "...d.version || ''"`, which emits **empty** (never the literal `undefined`) when a version is absent.

## Effect
- ✅ No more `vundefined`. Workflow now reads `@nxtg/faultline@0.8.0` (tag `v0.8.0` already exists).
- #16 will **auto-close** on the next run if the GH release / npm publish / CHANGELOG for v0.8.0 are in sync.
- If any of those are genuinely incomplete, #16 re-states as **real v0.8.0 drift** — correct behaviour, not a false positive. That's a real release-train decision for this repo, separate from the vundefined bug.

## Notes
- YAML validated (`yaml.safe_load`).
- **No** destructive remediation was run (no `git tag vundefined`, no `npm publish`).
- After merge, run `gh workflow run release-protocol-check.yml --repo nxtg-ai/faultline-pro` to re-evaluate #16 immediately instead of waiting for the daily schedule.
- Companion fix in nxtg-content-engine: `fc10352` (CE is not a publish target → opt-in gate). Portfolio context posted to /alignment.

🌽 Generated with NextGen AI - Intelligent Systems
https://nxtg.ai
Co-Authored-By: AxW <axw@nxtg.ai>